### PR TITLE
Enable namespasced entities unmarshalling

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/refurbed/sitemap
+
+go 1.24.1
+
+require (
+	github.com/nbio/xml v0.0.0-20250513004134-43b6474001b5
+	github.com/snabb/diagio v1.0.4
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+github.com/nbio/xml v0.0.0-20250513004134-43b6474001b5 h1:MktXAYjv6S/vumzlATGeh7ebycYD4YMv7Hg6iDF6RIc=
+github.com/nbio/xml v0.0.0-20250513004134-43b6474001b5/go.mod h1:990JnYmJZFrx1vI1TALoD6/fCqnWlTx2FrPbYy2wi5I=
+github.com/snabb/diagio v1.0.4 h1:XnlKoBarZWiAEnNBYE5t1nbvJhdaoTaW7IBzu0R4AqM=
+github.com/snabb/diagio v1.0.4/go.mod h1:Y+Pja4UJrskCOKaLxOfa8b8wYSVb0JWpR4YFNHuzjDI=

--- a/sitemap.go
+++ b/sitemap.go
@@ -6,10 +6,13 @@
 package sitemap
 
 import (
-	"encoding/xml"
-	"github.com/snabb/diagio"
 	"io"
 	"time"
+
+	// We use this package to have an ability to unmarshal namespaced-entities.
+	// See https://github.com/golang/go/issues/9519
+	"github.com/nbio/xml"
+	"github.com/snabb/diagio"
 )
 
 // ChangeFreq specifies change frequency of a sitemap entry. It is just a string.

--- a/sitemap_test.go
+++ b/sitemap_test.go
@@ -1,9 +1,12 @@
 package sitemap_test
 
 import (
-	"github.com/snabb/sitemap"
+	"bytes"
 	"os"
+	"testing"
 	"time"
+
+	"github.com/refurbed/sitemap"
 )
 
 func Example() {
@@ -17,11 +20,118 @@ func Example() {
 	sm.WriteTo(os.Stdout)
 	// Output:
 	// <?xml version="1.0" encoding="UTF-8"?>
-	// <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+	// <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xhtml="http://www.w3.org/1999/xhtml">
 	//   <url>
 	//     <loc>http://example.com/</loc>
 	//     <lastmod>1970-01-01T00:00:00Z</lastmod>
 	//     <changefreq>daily</changefreq>
 	//   </url>
 	// </urlset>
+}
+
+func TestSitemap_WriteTo(t *testing.T) {
+	sm := sitemap.New()
+	ts := time.Date(2025, 12, 30, 15, 55, 55, 0, time.UTC)
+	sm.Add(&sitemap.URL{
+		Loc:        "http://example.com/",
+		LastMod:    &ts,
+		ChangeFreq: sitemap.Daily,
+		Priority:   2.5,
+		Alternates: []*sitemap.AltURL{
+			{
+				Rel:      "alternate",
+				HrefLang: "de-at",
+				Loc:      "http://example.com/de-at/",
+			},
+		},
+	})
+
+	expectOut := `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xhtml="http://www.w3.org/1999/xhtml">
+  <url>
+    <loc>http://example.com/</loc>
+    <lastmod>2025-12-30T15:55:55Z</lastmod>
+    <changefreq>daily</changefreq>
+    <priority>2.5</priority>
+    <xhtml:link rel="alternate" hreflang="de-at" href="http://example.com/de-at/"></xhtml:link>
+  </url>
+</urlset>
+`
+
+	out := bytes.NewBuffer([]byte{})
+	_, err := sm.WriteTo(out)
+
+	if err != nil {
+		t.Fatalf("sitemap WriteTo got unexpected error: %q", err)
+	}
+	if expectOut != out.String() {
+		t.Errorf("sitemap WriteTo error.\nWant: %s\nGot: %s", expectOut, out.String())
+	}
+}
+
+func TestSitemap_ReadFrom(t *testing.T) {
+	contents := `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xhtml="http://www.w3.org/1999/xhtml">
+  <url>
+    <loc>http://example.com/</loc>
+    <lastmod>2025-12-30T15:55:55Z</lastmod>
+    <changefreq>daily</changefreq>
+    <priority>2.5</priority>
+    <xhtml:link rel="alternate" hreflang="de-at" href="http://example.com/de-at/"></xhtml:link>
+    <xhtml:link rel="alternate" hreflang="fr-fr" href="http://example.com/fr-fr/"></xhtml:link>
+  </url>
+</urlset>
+`
+	actualSm := sitemap.New()
+	_, err := actualSm.ReadFrom(bytes.NewBufferString(contents))
+	if err != nil {
+		t.Fatalf("sitemap WriteTo got unexpected error: %q", err)
+	}
+
+	actual := bytes.NewBuffer([]byte{})
+	actualSm.WriteTo(actual)
+
+	if contents != actual.String() {
+		t.Errorf("sitemap ReadFrom error.\nWant: %s\nGot: %s", contents, actual.String())
+	}
+}
+
+func TestSitemapEncodeDecodeRoundtrip(t *testing.T) {
+	expectedSitemap := sitemap.New()
+	ts := time.Date(2025, 12, 30, 15, 55, 55, 0, time.UTC)
+	expectedSitemap.Add(&sitemap.URL{
+		Loc:        "http://example.com/",
+		LastMod:    &ts,
+		ChangeFreq: sitemap.Daily,
+		Priority:   2.5,
+		Alternates: []*sitemap.AltURL{
+			{
+				Rel:      "alternate",
+				HrefLang: "de-at",
+				Loc:      "http://example.com/de-at/",
+			},
+			{
+				Rel:      "alternate",
+				HrefLang: "fr-fr",
+				Loc:      "http://example.com/fr-fr/",
+			},
+		},
+	})
+	expected := bytes.NewBuffer([]byte{})
+	_, err := expectedSitemap.WriteTo(expected)
+	if err != nil {
+		t.Fatalf("expectedSitemap WriteTo got unexpected error: %q", err)
+	}
+
+	actualSitemap := sitemap.New()
+	_, err = actualSitemap.ReadFrom(bytes.NewBufferString(expected.String()))
+	if err != nil {
+		t.Fatalf("actualSitemap WriteTo got unexpected error: %q", err)
+	}
+
+	actual := bytes.NewBuffer([]byte{})
+	actualSitemap.WriteTo(actual)
+	if expected.String() != actual.String() {
+		t.Errorf("sitemap encode-decode roundtrip error.\nWant: %s\nGot: %s", expected.String(), actual.String())
+	}
 }

--- a/sitemapindex.go
+++ b/sitemapindex.go
@@ -1,9 +1,12 @@
 package sitemap
 
 import (
-	"encoding/xml"
-	"github.com/snabb/diagio"
 	"io"
+
+	// We use this package to have an ability to unmarshal namespaced-entities.
+	// See https://github.com/golang/go/issues/9519
+	"github.com/nbio/xml"
+	"github.com/snabb/diagio"
 )
 
 // SitemapIndex is like Sitemap except the elements are named differently

--- a/sitemapindex_test.go
+++ b/sitemapindex_test.go
@@ -1,9 +1,12 @@
 package sitemap_test
 
 import (
-	"github.com/snabb/sitemap"
+	"bytes"
 	"os"
+	"testing"
 	"time"
+
+	"github.com/refurbed/sitemap"
 )
 
 func ExampleSitemapIndex() {
@@ -22,4 +25,111 @@ func ExampleSitemapIndex() {
 	//     <lastmod>1970-01-01T00:00:00Z</lastmod>
 	//   </sitemap>
 	// </sitemapindex>
+}
+
+func TestSitemapIndex_WriteTo(t *testing.T) {
+	sm := sitemap.NewSitemapIndex()
+	ts := time.Date(2025, 12, 30, 15, 55, 55, 0, time.UTC)
+	sm.Add(&sitemap.URL{
+		Loc:        "http://example.com/",
+		LastMod:    &ts,
+		ChangeFreq: sitemap.Daily,
+		Priority:   2.5,
+		Alternates: []*sitemap.AltURL{
+			{
+				Rel:      "alternate",
+				HrefLang: "de-at",
+				Loc:      "http://example.com/de-at/",
+			},
+		},
+	})
+
+	expectOut := `<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <sitemap>
+    <loc>http://example.com/</loc>
+    <lastmod>2025-12-30T15:55:55Z</lastmod>
+    <changefreq>daily</changefreq>
+    <priority>2.5</priority>
+    <xhtml:link rel="alternate" hreflang="de-at" href="http://example.com/de-at/"></xhtml:link>
+  </sitemap>
+</sitemapindex>
+`
+
+	out := bytes.NewBuffer([]byte{})
+	_, err := sm.WriteTo(out)
+
+	if err != nil {
+		t.Fatalf("sitemap WriteTo got unexpected error: %q", err)
+	}
+	if expectOut != out.String() {
+		t.Errorf("sitemap WriteTo error.\nWant: %s\nGot: %s", expectOut, out.String())
+	}
+}
+
+func TestSitemapIndex_ReadFrom(t *testing.T) {
+	contents := `<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <sitemap>
+    <loc>http://example.com/</loc>
+    <lastmod>2025-12-30T15:55:55Z</lastmod>
+    <changefreq>daily</changefreq>
+    <priority>2.5</priority>
+    <xhtml:link rel="alternate" hreflang="de-at" href="http://example.com/de-at/"></xhtml:link>
+    <xhtml:link rel="alternate" hreflang="fr-fr" href="http://example.com/fr-fr/"></xhtml:link>
+  </sitemap>
+</sitemapindex>
+`
+	actualSm := sitemap.NewSitemapIndex()
+	_, err := actualSm.ReadFrom(bytes.NewBufferString(contents))
+	if err != nil {
+		t.Fatalf("sitemap WriteTo got unexpected error: %q", err)
+	}
+
+	actual := bytes.NewBuffer([]byte{})
+	actualSm.WriteTo(actual)
+
+	if contents != actual.String() {
+		t.Errorf("sitemap ReadFrom error.\nWant: %s\nGot: %s", contents, actual.String())
+	}
+}
+
+func TestSitemapIndexEncodeDecodeRoundtrip(t *testing.T) {
+	expectedSitemap := sitemap.NewSitemapIndex()
+	ts := time.Date(2025, 12, 30, 15, 55, 55, 0, time.UTC)
+	expectedSitemap.Add(&sitemap.URL{
+		Loc:        "http://example.com/",
+		LastMod:    &ts,
+		ChangeFreq: sitemap.Daily,
+		Priority:   2.5,
+		Alternates: []*sitemap.AltURL{
+			{
+				Rel:      "alternate",
+				HrefLang: "de-at",
+				Loc:      "http://example.com/de-at/",
+			},
+			{
+				Rel:      "alternate",
+				HrefLang: "fr-fr",
+				Loc:      "http://example.com/fr-fr/",
+			},
+		},
+	})
+	expected := bytes.NewBuffer([]byte{})
+	_, err := expectedSitemap.WriteTo(expected)
+	if err != nil {
+		t.Fatalf("expectedSitemap WriteTo got unexpected error: %q", err)
+	}
+
+	actualSitemap := sitemap.NewSitemapIndex()
+	_, err = actualSitemap.ReadFrom(bytes.NewBufferString(expected.String()))
+	if err != nil {
+		t.Fatalf("actualSitemap WriteTo got unexpected error: %q", err)
+	}
+
+	actual := bytes.NewBuffer([]byte{})
+	actualSitemap.WriteTo(actual)
+	if expected.String() != actual.String() {
+		t.Errorf("sitemap encode-decode roundtrip error.\nWant: %s\nGot: %s", expected.String(), actual.String())
+	}
 }


### PR DESCRIPTION
It's not possible to unmarshall

```
Alternates []*AltURL  `xml:"xhtml:link"`
```

because of the namespaced entity.

This is a limitation of the standard Golang's `encoding/xml`.  See bug: https://github.com/golang/go/issues/9519

This PR also:
- Enables proper modern `go mod`.
- Adds unit tests.

Given that there is no CI running this is the local run of the the tests:
<img width="1002" height="669" alt="Screenshot 2025-08-01 at 21 41 56" src="https://github.com/user-attachments/assets/f562ea36-4f5b-475a-898e-25988260624b" />


